### PR TITLE
Security updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,23 @@
 				<groupId>org.mortbay.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>1.3.1</version>
+			</plugin>
 		</plugins>
 		<outputDirectory>src/main/webapp/WEB-INF/classes/</outputDirectory>
 	</build>
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>1.3.1</version>
+			</plugin>
+		</plugins>
+	</reporting>
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.jena</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.directwebremoting</groupId>
-			<artifactId>dwr-core</artifactId>
-			<version>3.0.0-rc2-SNAPSHOT</version>
+			<artifactId>dwr</artifactId>
+			<version>3.0.0-RELEASE</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>commons-logging</artifactId>
@@ -89,23 +89,6 @@
 			<groupId>net.sourceforge.collections</groupId>
 			<artifactId>collections-generic</artifactId>
 			<version>4.01</version>
-		</dependency>
-		<dependency>
-			<groupId>org.directwebremoting</groupId>
-			<artifactId>dwr-spring</artifactId>
-			<version>3.0.0-rc2-SNAPSHOT</version>
-			<exclusions>
-				<exclusion>
-					<artifactId>commons-logging</artifactId>
-					<groupId>commons-logging</groupId>
-				</exclusion>
-			</exclusions>
-
-		</dependency>
-		<dependency>
-			<groupId>org.directwebremoting</groupId>
-			<artifactId>dwr-protocol-dwrp</artifactId>
-			<version>3.0.0-rc2-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,11 @@
 		  <artifactId>xml-apis</artifactId>
 		  <version>1.4.01</version>
 		</dependency>
+		<dependency>
+			<groupId>commons-fileupload</groupId>
+			<artifactId>commons-fileupload</artifactId>
+			<version>1.3.1</version>
+		</dependency>
 	</dependencies>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,11 @@
 			<artifactId>commons-fileupload</artifactId>
 			<version>1.3.1</version>
 		</dependency>
+		<dependency>
+			<groupId>org.jdom</groupId>
+			<artifactId>jdom</artifactId>
+			<version>1.1.3</version>
+		</dependency>
 	</dependencies>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -285,6 +285,14 @@
 			<name>Springframework Maven OSGified Artifacts Repository</name>
 			<url>http://maven.springframework.org/osgi</url>
 		</repository>
+		<repository>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>central</id>
+			<name>Maven Repository Switchboard</name>
+			<url>http://repo1.maven.org/maven2</url>
+		</repository>
 	</repositories>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-webmvc</artifactId>
-			<version>3.2.2.RELEASE</version>
+			<version>3.2.15.RELEASE</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>commons-logging</artifactId>
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context-support</artifactId>
-			<version>3.2.2.RELEASE</version>
+			<version>3.2.15.RELEASE</version>
 			<scope>runtime</scope>
 			<exclusions>
 				<exclusion>

--- a/src/main/webapp/WEB-INF/app/saha3/admin.ftl
+++ b/src/main/webapp/WEB-INF/app/saha3/admin.ftl
@@ -3,10 +3,10 @@
 <html>
 <head>
 <title>SAHA3 Admin Screen</title>
-<script type='text/javascript' src='../dwr/interface/SahaProjectRegistry.js'></script>
-<script type='text/javascript' src='../dwr/interface/SahaChat.js'></script>
 <script type='text/javascript' src='../dwr/engine.js'></script>
 <script type='text/javascript' src='../dwr/util.js'></script>
+<script type='text/javascript' src='../dwr/interface/SahaProjectRegistry.js'></script>
+<script type='text/javascript' src='../dwr/interface/SahaChat.js'></script>
 <script>
 function close_project(model) {
 	document.body.style.cursor="progress";

--- a/src/main/webapp/WEB-INF/app/saha3/support/saha3_common.ftl
+++ b/src/main/webapp/WEB-INF/app/saha3/support/saha3_common.ftl
@@ -11,10 +11,10 @@
 	</script>
 
 
+	<script type='text/javascript' src='../dwr/engine.js'></script> 
 	<script type='text/javascript' src='../dwr/interface/ResourceEditService.js'></script>
 	<script type='text/javascript' src='../dwr/interface/ResourceConfigService.js'></script>
 	<script type='text/javascript' src='../dwr/interface/SahaChat.js'></script>
-	<script type='text/javascript' src='../dwr/engine.js'></script> 
 	<script type='text/javascript' src='../app/scripts/dwr_resources/util.js'></script> 
 	<script type='text/javascript' src='../app/scripts/dojo.js'></script>
 


### PR DESCRIPTION
Moi,

Kirjastot.fi:n päivityskierroksessa katselin sahan dependenssit läpi OWASP Dependency Check -työkalulla, joka tarkistaa yleisistä tietokannoista onko niissä tunnettuja aukkoja. Päivitin Mavenin uudempaan versioon, kun siinä oli useita issueita. Käytössä olevassa httpclient-4.2.3 on myös:
- http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-5262
- http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-3577

mutta nämä koskevat SSL-yhteyksiä ja niitä ei ilmeisesti ole käytössä sahassa. Tuota httpclientiä ei tuntunut voivan päivittääkään versioon, jossa noita ongelmia ei ollut.

Päivitetty versio on nyt ajossa saha.kirjastot.fi:ssä.

Jaakko Lindvall
jaakko.lindvall@kirjastot.fi
